### PR TITLE
Fix showme and places missing nop (Compatibility with tintin 2.02.02)

### DIFF
--- a/modules/general.tin
+++ b/modules/general.tin
@@ -49,7 +49,7 @@
 
 #macro {\e[11~} {!}
 
-#CONFIG           {256 COLORS}  {ON}
+#nop #CONFIG           {256 COLORS}  {ON}
 #CONFIG           {AUTO TAB}  {5000}
 #CONFIG           {BUFFER SIZE}  {20000}
 #CONFIG           {CHARSET}  {ASCII}

--- a/modules/gmcp.tin
+++ b/modules/gmcp.tin
@@ -245,8 +245,8 @@
     };
 
     #if {$ticks < 10}
-    {#show {<139>  $ticks<099> secs to tick     QUEST<099>: <139>$timer} 3}
-    {#show {<139> $ticks<099> secs to tick     QUEST<099>: <139>$timer} 3}
+    {#show {<139>  $ticks<099> secs to tick     QUEST<099>: <139>$timer} {-4} {3}}
+    {#show {<139> $ticks<099> secs to tick     QUEST<099>: <139>$timer} {-4} {3}}
 }
 {1};
 #EVENT {IAC WILL GMCP}

--- a/modules/gmcp.tin
+++ b/modules/gmcp.tin
@@ -210,7 +210,7 @@
 				    #map set roomcolor <178>
 			};
 
-			#foreach {$GMCP[ROOM][INFO][exits][]} {exit}
+			#foreach {*GMCP[ROOM][INFO][exits][]} {exit}
 			{
 				    #map get {roomexit} {mapresult};
 

--- a/modules/spellup.tin
+++ b/modules/spellup.tin
@@ -1,7 +1,7 @@
 #class spellup kill;
 #class spellup open;
 
-# Configure this part for your clan skill
+#nop Configure this part for your clan skill
 #variable {clanskill_command} {exaltation}
 
 #ALIAS {^spup{| spup}}
@@ -10,7 +10,7 @@
 	#send {spellup learned};
 }
 
-# Configure these actions to catch clan skill turning on and off
+#nop Configure these actions to catch clan skill turning on and off
 #ACTION {^{Familiar words are whispered into your ear, Athena's power floods your veins.|You've already summoned the powers of Athena.}}                  
 {                                                                                                                                                         
     #var {clanskill} {1};                                                                                                                                
@@ -21,7 +21,7 @@
     #var {clanskill} {0};                                                                                                                                
 }
 
-# Catch spell tag data
+#nop Catch spell tag data
 #ACTION {^%d,%2,%d,%d,%d,%6,%d$}
 {
 	#if {%3 == 2 || %3 == 3}

--- a/modules/ticking.tin
+++ b/modules/ticking.tin
@@ -14,11 +14,11 @@
 		};
 		#if {$ticks < 10}
     		{
-			#show {Tick:<139> $ticks <099>QUEST: <139>$quest_timer<099> Exp:<139> $GMCP[CHAR][STATUS][tnl] <099>Align:$align} 3
+			#show {Tick:<139> $ticks <099>QUEST: <139>$quest_timer<099> Exp:<139> $GMCP[CHAR][STATUS][tnl] <099>Align:$align} {-4} 3
 		}
 		
 		{
-			#show {Tick:<139>$ticks <099>QUEST: <139>$quest_timer<099> Exp:<139> $GMCP[CHAR][STATUS][tnl] <099>Align:$align} 3
+			#show {Tick:<139>$ticks <099>QUEST: <139>$quest_timer<099> Exp:<139> $GMCP[CHAR][STATUS][tnl] <099>Align:$align} {-4} 3
 		}
 	} {1}
 }

--- a/modules/zzGMCP_to_stat.tin
+++ b/modules/zzGMCP_to_stat.tin
@@ -54,7 +54,7 @@
 		#variable fighting n
 	};
 	#variable {prompt} {$prompt<099>};
-	#showme {$prompt} {2}
+	#showme {$prompt} {-3} {3}
 }
 {5}
 

--- a/setup.tin
+++ b/setup.tin
@@ -1,6 +1,6 @@
-#VARIABLE {name} {};				# Character name
-#VARIABLE {password} {};			# Character password
-#VARIABLE {dir} {.};				# Directory of setings, without '/' or '~' (Ex. /home/user/aardwolf, not ~/aardwolf )
+#VARIABLE {name} {}; #nop Character name
+#VARIABLE {password} {}; #nop Character password
+#VARIABLE {dir} {.}; #nop Directory of setings, without '/' or '~' (Ex. /home/user/aardwolf, not ~/aardwolf )
 
 #READ {$dir/modules/gmcp.tin};
 
@@ -14,7 +14,7 @@
 #READ {$dir/modules/ticking.tin}
 #READ {$dir/modules/quest.tin}
 
-#MAP READ {$dir/map/map-all.tt}				# Once you have a map file, you will read it in here
+#MAP READ {$dir/map/map-all.tt}; #nop Once you have a map file, you will read it in here
 
 #LOG APPEND {$dir/log/active_log.raw}
 


### PR DESCRIPTION
The `#showme` command now uses negative numbers for positioning on the bottom split and there is now a border on the sides so I made changes to position them like before.

Also I added a few missing `#nop` for comments which now report as errors in later versions of tintin.